### PR TITLE
Remove redundant `is_active` column from `SubscriptionPlan`

### DIFF
--- a/forloop_common_structures/core/plan.py
+++ b/forloop_common_structures/core/plan.py
@@ -16,7 +16,6 @@ class SubscriptionPlan:
     max_collaborators: int
     is_active: bool
     description: str
-    is_active: bool
     uid: Optional[str] = None
 
 @dataclass


### PR DESCRIPTION
Dependency to:
- https://github.com/ForloopAI/forloop_platform/pull/961